### PR TITLE
Makefile: change sleep 10 to until loop that waits until mysql is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ start-mysql:	## start mysql server
 
 init:	## start mysql server
 	docker-compose up -d mysql
-	sleep 10
+	## Test condition from https://stackoverflow.com/questions/25503412/how-do-i-know-when-my-docker-mysql-container-is-up-and-mysql-is-ready-for-taking (answer by Matt Kramer)
+	until docker container exec aspace-dev-docker_mysql_1 mysql --user=root --password=password -e "SELECT 1" >/dev/null 2>&1; do : ; done
 	docker-compose exec mysql mysql -u root -ppassword -e 'create database archivesspace default character set utf8;'
 	docker-compose exec mysql mysql -u root -ppassword -e "grant all on archivesspace.* to 'archivesspace'@'%' identified by 'archivesspace';"
 	docker-compose up -d aspace


### PR DESCRIPTION
The `sleep 10` wasn't working on my machine.
First tried replacing it with an `until` loop that waited for the existence of /var/lib/mysql/mysql.sock, but it turns out that subsequent commands can still fail even after that file is created.  Apparently MySQL is not necessarily completely ready for service after the mysql.sock file is generated, more needs to happen.
Replaced the `until` loop test with one I found on Stackoverflow that checks for the successful execution of a dummy query.  Did a full test and `make init` did a correct wait and execution proceeded normally afterward.
